### PR TITLE
Remove megaboost from APY

### DIFF
--- a/apps/ycrv/contexts/useYCRV.tsx
+++ b/apps/ycrv/contexts/useYCRV.tsx
@@ -216,7 +216,8 @@ export const YCRVContextApp = ({children}: {children: ReactElement}): ReactEleme
 	** Compute the styCRV APY based on the experimental APY and the mega boost.
 	**************************************************************************/
 	const	styCRVAPY = useMemo((): number => {
-		return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100) + (styCRVMegaBoost * 100);
+		return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100);
+		// return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100) + (styCRVMegaBoost * 100);
 		// return (styCRVExperimentalAPY * 100) + (styCRVMegaBoost * 100);
 	}, [styCRVVault, styCRVMegaBoost]);
 


### PR DESCRIPTION
This should correct the headline APY and bring it back in sync with the APY displayed on the vaults page.